### PR TITLE
A few fixes

### DIFF
--- a/bin/nts
+++ b/bin/nts
@@ -54,7 +54,8 @@ def url_matcher(url):
             nts.download(url=url, quiet=options.quiet, save_dir=download_dir)
         elif match_sh:
             episodes = nts.get_episodes_of_show(match_sh.group(1))
-            url_matcher(episodes)
+            for ep in episodes:
+                url_matcher(ep)
         else:
             print(f'{url} is not an NTS url.\n')
             parser.print_help()

--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -254,7 +254,17 @@ def main():
         exit(1)
 
     arg = sys.argv[1]
-    lines = [arg]
+    line = arg
+
+    match_episode = re.match(episode_regex, line)
+    match_show = re.match(show_regex, line)
+
+    lines = []
+
+    if match_episode:
+        lines += line.strip()
+    elif match_show:
+        lines += get_episodes_of_show(match_show.group(1))
 
     if os.path.isfile(arg):
         # read list
@@ -263,16 +273,12 @@ def main():
             file = f.read()
         lines = filter(None, file.split('\n'))
 
+    if len(lines) == 0:
+        print('Didn\'t find shows to download.')
+        exit (1)
+
     for line in lines:
-        match_episode = re.match(episode_regex, line)
-        match_show = re.match(show_regex, line)
-        if match_episode:
-            download(line.strip())
-        elif match_show:
-            lines += get_episodes_of_show(match_show.group(1))
-        else:
-            print(f'{line} is not an NTS url.')
-            exit(1)
+        download(line, False, download_dir)
 
 
 if __name__ == "__main__":

--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -97,7 +97,8 @@ def download(url, quiet, save_dir, save=True):
                 # comment
                 audio['\xa9cmt'] = nts_url
                 # genre
-                audio['\xa9gen'] = parsed['genres'][0]
+                if len(parsed['genres']) != 0:
+                    audio['\xa9gen'] = parsed['genres'][0]
                 # cover
                 if image_type != '':
                     match = re.match(r'jpe?g$', image_type)


### PR DESCRIPTION
Hi, thanks for the great program. It didn't work immediately for me, but with a couple fixes it works perfectly. I'm running macOS with `python 3.7` installed via `brew`.

Here is a summary of the changes (nothing crazy, just fixes):
- Looks like mixcloud is now client-side rendered and the image is not available. I've made it error out gracefully (in which case there is simply no album art), or find the nts show background image (better than nothing)
- Sometimes (I was testing with https://www.nts.live/shows/szare), there is no genre, and this was erroring out. Again, handled gracefully, there is simply no genre in the file if we can't find one in the page
- Downloading an entire show didn't work, simple fix
- Invoking directly `nts/download.py` (presumably for testing) didn't work

I tested on a couple shows I liked and it seems to work OK, lmk what you think.

Thanks again for writing this in the first place!