### PR TITLE
Cover cases where there is no station

### DIFF
--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -123,7 +123,10 @@ def parse_nts_data(bs):
     # parse artists in the title
     artists, parsed_artists = parse_artists(title, bs)
 
-    station = title_box.div.div.h2.find(text=True, recursive=False).strip()
+    if title_box.div.div.h2.find(text=True, recursive=False):
+        station = title_box.div.div.h2.find(text=True, recursive=False).strip()
+    else:
+        station = 'London'
 
     bg_tag = bs.select('section#bg[style]')
     background_image_regex = r'background-image:url\((.*)\)'

--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -123,10 +123,11 @@ def parse_nts_data(bs):
     # parse artists in the title
     artists, parsed_artists = parse_artists(title, bs)
 
-    if title_box.div.div.h2.find(text=True, recursive=False):
-        station = title_box.div.div.h2.find(text=True, recursive=False).strip()
-    else:
+    station = title_box.div.div.h2.find(text=True, recursive=False)
+    if not station:
         station = 'London'
+    else:
+        station = station.strip()
 
     bg_tag = bs.select('section#bg[style]')
     background_image_regex = r'background-image:url\((.*)\)'


### PR DESCRIPTION
I found that in a few cases the download would fail because there was no `station`, so I've added a simple test, with the default value of `London` if nothing is found. I'm sure this could be made more elegant...