### PR TITLE
Mux webm and opus to ogg

### DIFF
--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -10,6 +10,7 @@ import requests
 from yt_dlp import YoutubeDL
 from cssutils import parseStyle
 from bs4 import BeautifulSoup
+import ffmpeg
 
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import ID3, APIC, COMM, USLT
@@ -134,6 +135,14 @@ def download(url, quiet, save_dir, save=True):
                 # .m4a and .mp3 use different methods
                 _, file_ext = os.path.splitext(file)
                 file_ext = file_ext.lower()
+
+                if file_ext == '.webm' or file_ext == '.opus':
+                    old_file_path = os.path.join(save_dir, file)
+                    file = file_name + '.ogg'
+                    new_file_path = os.path.join(save_dir, file)
+                    ffmpeg.input(old_file_path).output(new_file_path, acodec='copy').run(overwrite_output=True)
+                    os.remove(old_file_path)
+                    file_ext = '.ogg'
 
                 if file_ext == '.m4a':
                     set_m4a_metadata(os.path.join(save_dir, file), parsed,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4==4.9.3
 mutagen==1.45.1
 requests==2.32.2
 cssutils==2.7.1
+ffmpeg-python==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         'mutagen==1.45.1',
         'requests==2.32.2',
         'cssutils==2.7.1',
+        'ffmpeg-python==0.2.0'
     ],
     python_requires='>=3.7.5',
 )


### PR DESCRIPTION
The latest update of yt-dlp downloads opus from soundcloud and webm from mixcloud. This will mux them into an ogg container.

Adds ffmpeg requirement.