### PR TITLE
Fix Artist Regex Strings

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -10,9 +10,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 import ffmpeg
 import music_tag
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 # defaults to darwin
 download_dir = '~/Downloads'

--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -218,7 +218,7 @@ def parse_genres(bs):
 
 def parse_artists(title, bs):
     # parse artists in the title
-    parsed_artists = re.findall(r'(?:w\/|with)(.+?)(?=and|,|&|\s-\s)', title,
+    parsed_artists = re.findall(r'(?:w\/|with)(.+?)(?=\sand\s|,|&|\s-\s)', title,
                                 re.IGNORECASE)
     if not parsed_artists:
         parsed_artists = re.findall(r'(?:w\/|with)(.+)', title, re.IGNORECASE)
@@ -226,14 +226,14 @@ def parse_artists(title, bs):
     parsed_artists = [x.strip() for x in parsed_artists]
     # get other artists after the w/
     if parsed_artists:
-        more_people = re.sub(r'^.+?(?:w\/|with)(.+?)(?=and|,|&|\s-\s)', '',
+        more_people = re.sub(r'^.+?(?:w\/|with)(.+?)(?=\sand\s|,|&|\s-\s)', '',
                              title, re.IGNORECASE)
         if more_people == title:
             # no more people
             more_people = ''
         if not re.match(r'^\s*-\s', more_people):
             # split if separators are encountered
-            more_people = re.split(r',|and|&', more_people, re.IGNORECASE)
+            more_people = re.split(r',|\sand\s|&', more_people, re.IGNORECASE)
             # append to array
             if more_people:
                 for mp in more_people:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nts-everdrone",
-    version="1.3.2",
+    version="1.3.3",
     author="Giorgio Tropiano",
     author_email="giorgiotropiano@gmail.com",
     description="NTS Radio downloader tool",


### PR DESCRIPTION
## Description

Artist regex strings would incorrectly parse names that contain the characters `and` as separate artists. Should assume that the word `and` will be surrounded by spaces if there are multiple artists.

## Example 1

`nts https://www.nts.live/shows/forager-records/episodes/forager-records-7th-november-2024`

The artist `Brandon McMahon` gets parsed to `Br; on McMahon`.

After the changes from this PR, the artist is correctly parsed:

`      artist          : Brandon McMahon`

## Example 2

This show title contains the name `Randy` and a standalone ` and `:

`nts https://www.nts.live/shows/day-care/episodes/day-care-18th-november-2024`

The artists are incorrectly parsed:

      artist          : R; y Ellis;  The Alaia and Guest Darone Sassounian

Applying the new regexes, the artists are correctly parsed:

`      artist          : Randy Ellis;  The Alaia; Guest Darone Sassounian`

## Future Considerations

- Shows without a `w/` or `with`  in the title get a blank artist tag. This could be desirable for some applications, but for a Plex library for example, it would probably be better to have the artist and title be same instead of one being blank (and getting auto-assigned from the folder structure). I also love the idea of having this be configurable as part of the CLI.
- It may also be a good idea to remove `Guest` from the artist strings too.