### PR TITLE
Fix f-string syntax error in downloader.py

### DIFF
--- a/nts/downloader.py
+++ b/nts/downloader.py
@@ -263,7 +263,7 @@ def get_comment(parsed):
     desc = parsed.get('description', '')
     if len(desc) > 0:
         comment = desc + '\n'
-    comment += f'Station Location: {parsed['station']}\n'
+    comment += f"Station Location: {parsed['station']}\n"
     comment += parsed['url']
     return comment
 


### PR DESCRIPTION
This PR fixes a small syntax error that prevented the tool from running - 

Running `nts [link]` produced the following traceback: 
```
Traceback (most recent call last):
  File "/home/cashew/.local/bin/nts", line 5, in <module>
    from nts.cli import main
  File "/home/cashew/.local/lib/python3.10/site-packages/nts/cli.py", line 6, in <module>
    from nts import downloader as nts
  File "/home/cashew/.local/lib/python3.10/site-packages/nts/downloader.py", line 266
    comment += f'Station Location: {parsed['station']}\n'
                                            ^^^^^^^
SyntaxError: f-string: unmatched '['
```

f-string used single quotes for both string and dictionary key (downloader.py line 266) so changed outer string to double quotes.

Now runs without errors.